### PR TITLE
No extension not depreciated

### DIFF
--- a/src/language/includes.md
+++ b/src/language/includes.md
@@ -32,7 +32,7 @@ footer#footer
 
 The path of the included file, if specified absolutely (e.g. `include /root.pug`), is resolved by prepending `options.basedir` to the file name provided. Otherwise, the path is relative to the current file being compiled.
 
-In Pug v1, if no file extension is given, `.pug` is automatically appended to the file name, but in Pug v2 this is behavior is deprecated.
+If no file extension is given, `.pug` is automatically appended to the file name.
 
 ## Including Plain Text
 

--- a/src/language/inheritance.md
+++ b/src/language/inheritance.md
@@ -26,7 +26,7 @@ html
 
 Now to extend the layout, simply create a new file and use the `extends` directive as shown below, giving the path. You may now define one or more blocks that will override the parent block content, note that here the `foot` block is *not* redefined and will output "some footer content".
 
-In Pug v1, if no file extension is given, `.pug` is automatically appended to the path, but in Pug v2 this is behavior is deprecated.
+If no file extension is given, `.pug` is automatically appended to the file name.
 
 ```pug
 //- page-a.pug


### PR DESCRIPTION
Inferring .pug extension is not currently depreciated, adjust docs accordingly.
Did not touch examples, they all include .pug