### PR TITLE
Clarify object iteration example

### DIFF
--- a/src/language/conditionals.md
+++ b/src/language/conditionals.md
@@ -11,7 +11,7 @@ Pug's first-class conditional syntax allows for optional parentheses.
 If you’re coming from Pug v1, you may now omit the leading `-`. Otherwise, it's identical (just regular JavaScript):
 
 ```pug-preview
-- var user = { description: 'foo bar baz' }
+- var user = {description: 'foo bar baz'}
 - var authorised = false
 #user
   if user.description

--- a/src/language/iteration.md
+++ b/src/language/iteration.md
@@ -30,7 +30,7 @@ Pug also lets you iterate over the keys in an object:
 
 ```pug-preview
 ul
-  each val, index in {1:'one',2:'two',3:'three'}
+  each val, index in {1: 'one', 2: 'two', 3: 'three'}
     li= index + ': ' + val
 ```
 

--- a/src/language/iteration.md
+++ b/src/language/iteration.md
@@ -30,8 +30,8 @@ Pug also lets you iterate over the keys in an object:
 
 ```pug-preview
 ul
-  each val, index in {1: 'one', 2: 'two', 3: 'three'}
-    li= index + ': ' + val
+  each val, key in {1: 'one', 2: 'two', 3: 'three'}
+    li= key + ': ' + val
 ```
 
 The object or array to iterate over is just plain JavaScript. So, it can be a variable, or the result of a function call, or almost anything else.


### PR DESCRIPTION
Refer to object's "key" rather than "index"

This PR also adjusts the format of a couple JS objects to match the style used elsewhere in the Pug documentation.