### PR TITLE
Add .pug file extension for consistency

### DIFF
--- a/src/language/inheritance.md
+++ b/src/language/inheritance.md
@@ -110,7 +110,7 @@ When using `block append` or `block prepend`, the word “`block`” is optional
 
 ```pug
 //- page.pug
-extends layout
+extends layout.pug
 
 append head
   script(src='/vendor/three.js')


### PR DESCRIPTION
Even though the file extension is not required in this instance, it should be included to be consistent with other examples.