### PR TITLE
[nit] api: migration-v3: Set page title to v3, not v2

### DIFF
--- a/src/api/migration-v3.md
+++ b/src/api/migration-v3.md
@@ -1,5 +1,5 @@
 ---
-title: Migrating to Pug 2
+title: Migrating to Pug 3
 template: generic
 id: api/migration-v3
 ---


### PR DESCRIPTION
Nit, probably got copy-pasted and overlooked when writing the v3 guide with v2 as a baseline.